### PR TITLE
fix: tenantId is always a string

### DIFF
--- a/src/domain-event.ts
+++ b/src/domain-event.ts
@@ -4,7 +4,7 @@ export interface IDomainEvent<T = null> {
   // id for the Aggregate Root that this event belongs to
   aggregateId: string;
   // support multi-tenant applications
-  tenantId: string | null;
+  tenantId: string;
   // Optional Event data
   data: T | null;
 }
@@ -29,7 +29,7 @@ export abstract class AbstractDomainEvent<T = null> implements IDomainEvent<T> {
   constructor(ctx: IEventConstructorContext, data?: T) {
     this.aggregateId = ctx.aggregateId;
     this.timestamp = new Date().toISOString();
-    this.tenantId = ctx.tenantId ?? null;
+    this.tenantId = ctx.tenantId ?? '';
     this.data = data ?? null;
   }
 }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -26,13 +26,13 @@ export abstract class Entity<
 > implements IEntity
 {
   private readonly _id: string;
-  private readonly _tenantId: string | null;
+  private readonly _tenantId: string;
 
   protected readonly _data: Omit<T, 'id' | 'tenantId'>;
 
   // Make `id` optional accounting for re-consituting objects from persistence
   constructor(data?: T) {
-    this._tenantId = data?.tenantId ?? null;
+    this._tenantId = data?.tenantId ?? '';
     this._id = data?.id ?? uuid();
 
     // remove captured fields, if they exist


### PR DESCRIPTION
- If consumers are working with single tenant apps, then the `tenantId` fields will not be used. So this should have no effect but will remove unnecessary type checks for apps that do need multi-tenant support