### PR TITLE
fix: unnecessary optional chaining in multi-tenant apps for tenantId

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -6,7 +6,8 @@ const isEntity = (v: unknown): v is Entity<any> => v instanceof Entity;
 export interface IEntity {
   readonly id: string;
   // support multi-tenant applications
-  readonly tenantId: string | null;
+  // Note: empty string if tenant isn't required
+  readonly tenantId: string;
 
   equals(object?: IEntity): boolean;
 }
@@ -25,8 +26,8 @@ export abstract class Entity<
   T extends Partial<defaultConstructorData> = Partial<defaultConstructorData>,
 > implements IEntity
 {
-  private readonly _id: string;
-  private readonly _tenantId: string;
+  private readonly _id: IEntity['id'];
+  private readonly _tenantId: IEntity['tenantId'];
 
   protected readonly _data: Omit<T, 'id' | 'tenantId'>;
 


### PR DESCRIPTION
⚠️ Should be merged after #15 

# Summary

Remove unnecessary type checks when in a multi-tenant app. If in a single tenanted app -- or delineating tenants isn't of importance -- then the Domain will model this as an empty string. This saves unnecessary optional chaining.
