### PR TITLE
fix: make domain event handler event type extensible

### DIFF
--- a/src/domain-event.ts
+++ b/src/domain-event.ts
@@ -10,9 +10,10 @@ export interface IDomainEvent<T = null> {
 }
 
 // Prototype for functions that will consume Domain Events
-export type DomainEventHandler<T = null> = (
-  event: IDomainEvent<T>,
-) => void | Promise<void>;
+export type DomainEventHandler<
+  T = null,
+  E extends IDomainEvent<T> = IDomainEvent<T>,
+> = (event: E) => void | Promise<void>;
 
 export type IEventConstructorContext = Omit<IDomainEvent, 'timestamp' | 'data'>;
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -6,7 +6,8 @@ const isEntity = (v: unknown): v is Entity<any> => v instanceof Entity;
 export interface IEntity {
   readonly id: string;
   // support multi-tenant applications
-  readonly tenantId: string | null;
+  // Note: empty string if tenant isn't required
+  readonly tenantId: string;
 
   equals(object?: IEntity): boolean;
 }
@@ -25,8 +26,8 @@ export abstract class Entity<
   T extends Partial<defaultConstructorData> = Partial<defaultConstructorData>,
 > implements IEntity
 {
-  private readonly _id: string;
-  private readonly _tenantId: string;
+  private readonly _id: IEntity['id'];
+  private readonly _tenantId: IEntity['tenantId'];
 
   protected readonly _data: Omit<T, 'id' | 'tenantId'>;
 


### PR DESCRIPTION
# Summary

Make domain event handler type generic to expose extensions to better align to types on the Aggregate root and its Domain events.