### PR TITLE
Fix Entity types

### DIFF
--- a/src/entity.test.ts
+++ b/src/entity.test.ts
@@ -4,7 +4,7 @@ import { Entity } from './entity';
 describe('Entity', () => {
   it("sets it's own id for new objects", () => {
     class TestEntity extends Entity {}
-    const obj = new TestEntity();
+    const obj = new TestEntity({});
 
     expect(obj.id).toBeString();
     expect(obj.id.length).toBeGreaterThan(0);
@@ -35,7 +35,7 @@ describe('Entity', () => {
   it('correctly compares two identical entities', () => {
     class TestEntity extends Entity {}
 
-    const obj1 = new TestEntity();
+    const obj1 = new TestEntity({});
 
     expect(obj1.equals(obj1)).toBeTrue();
   });
@@ -45,7 +45,7 @@ describe('Entity', () => {
 
     const preexistingId = uuid();
     const obj1 = new TestEntity({ id: preexistingId });
-    const obj2 = new TestEntity();
+    const obj2 = new TestEntity({});
 
     expect(obj1.equals(obj2)).toBeFalse();
   });

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -58,3 +58,25 @@ export abstract class Entity<T extends IBaseEntityData = IBaseEntityData>
     return Object.is(this, object) || this._id === object.id;
   }
 }
+
+//
+// Utility Types
+//
+
+/**
+ * Create the type for the custom (data) attributes of an Entity.
+ *
+ * Note: The attribute getters/setters will still have to be defined manually within your Entity object.
+ */
+export type BuildEntityDataType<T> = T & IBaseEntityData;
+
+/**
+ * Create the public interface of the resulting Entity.
+ * This allows you to depend on an abstraction over a concretion.
+ */
+export type BuildEntityInterface<T> = IEntity &
+  Exclude<
+    // The nested `Exclude` "cleans" up the type if a consumer passes the result of the `BuildEntityDataType` helper
+    BuildEntityDataType<Exclude<T, 'IBaseEntityData'>>,
+    'IBaseEntityData'
+  >;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -12,27 +12,26 @@ export interface IEntity {
   equals(object?: IEntity): boolean;
 }
 
-interface defaultConstructorData {
-  tenantId: string;
-  id: string;
-}
+type IBaseEntityData = Partial<{
+  tenantId: IEntity['tenantId'];
+  id: IEntity['id'];
+}>;
 
 /**
  * An object whose definition is based on `identity` over just its attributes.
  *
  * Also known as `Reference Objects`.
  */
-export abstract class Entity<
-  T extends Partial<defaultConstructorData> = Partial<defaultConstructorData>,
-> implements IEntity
+export abstract class Entity<T extends IBaseEntityData = IBaseEntityData>
+  implements IEntity
 {
   private readonly _id: IEntity['id'];
   private readonly _tenantId: IEntity['tenantId'];
 
   protected readonly _data: Omit<T, 'id' | 'tenantId'>;
 
-  // Make `id` optional accounting for re-consituting objects from persistence
-  constructor(data?: T) {
+  // Make `id` optional: allow for re-consituting objects from persistence
+  constructor(data: T) {
     this._tenantId = data?.tenantId ?? '';
     this._id = data?.id ?? uuid();
 
@@ -40,8 +39,6 @@ export abstract class Entity<
     delete data?.id;
     delete data?.tenantId;
 
-    // @ts-expect-error
-    // fixme: check typing
     this._data = data ?? {};
   }
 


### PR DESCRIPTION
# Summary

Fix the typing on `Entity` custom data attributes. 

Also provide Type helpers to build custom data attribute types and the Entity interface types.

## Example

And example of how this works. 

 ```ts
// we'll write this as 2 separate import statements to be explicit on what is a value and what is a type
import type { BuildEntityDataType, BuildEntityInterface } from 'ddd-ts';
import { Entity } from 'ddd-ts';

// Automatically handle core features (value / types) for your custom Entity data. 
type IMyEntityData = BuildEntityDataType<{
  label: string;
}>;

// Automatically expose your custom data with all base public functionality exposed by the Entity class
export type IMyEntity = BuildEntityInterface<IMyEntityData>;

// Create your custom Entity object
export class MyEntity extends Entity<IMyEntityData> implements IMyEntity {
  constructor(label: string, id?: string) {
    super({ label: label.trim(), id });
  }

  /*
   * We still need to manually define our getter/setters for our custom attributes, where it makes sense do so.
   */
  public get label() {
    return this._data.label;
  }

  public set label(newLabel: string) {
    this._data.label = newLabel.trim();
  }
}
```