### PR TITLE
ci: do not check external links

### DIFF
--- a/.md-link-check.config.json
+++ b/.md-link-check.config.json
@@ -1,4 +1,5 @@
 {
+  "ignorePatterns": [{ "pattern": "^http" }],
   "replacementPatterns": [
     {
       "pattern": "^/",


### PR DESCRIPTION
# Summary

Limit link checking to internal MD links. Ultimately will streamline and speed up the CI.