### PR TITLE
fix: ensure domain event handler extends the base contract for events

### DIFF
--- a/src/domain-events-broker.ts
+++ b/src/domain-events-broker.ts
@@ -42,7 +42,7 @@ export class DomainEventsBroker {
    */
   public static registerEventHandler(
     eventName: string,
-    handler: DomainEventHandler<any>,
+    handler: DomainEventHandler,
   ): void {
     this.eventHandlers.set(
       eventName,


### PR DESCRIPTION
# Summary

Do not override the contract / shape of domain `event` in the event handlers. This fixes a type warning when trying to consume a domain event in a handler. 