### PR TITLE
docs: call out nodejs on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # DDD-TS
 
-Build (multi-tenanted) apps with [Domain Driven Design (DDD)][fowler-ddd] and Typescript with ease.
+Build (multi-tenanted) apps with [Domain Driven Design (DDD)][fowler-ddd], Typescript and NodeJS with ease.
 
-> ⚠️ Although at Beamery we use this package in production, this package should be considered an Alpha level release and thus subject to breaking changes as we stabilise the API. A v1.0.0 release will signal a stabilsed API.
+> ⚠️ This package should be considered an Alpha level release and thus subject to breaking changes as we stabilise the API. A v1.0.0 release will signal a stabilsed API.
 
 ---
 


### PR DESCRIPTION
# Summary

Following from the change to the build system in #23 , call out that this package is intended for use on the server side only. 

## Notes

- Clean up alpha notice.